### PR TITLE
`mlflow_run()` improvements

### DIFF
--- a/R/mlflow/DESCRIPTION
+++ b/R/mlflow/DESCRIPTION
@@ -24,7 +24,9 @@ Imports:
   swagger,
   withr,
   xml2,
-  yaml
+  yaml,
+  fs,
+  stringr
 RoxygenNote: 6.0.1
 Suggests: 
   testthat

--- a/R/mlflow/DESCRIPTION
+++ b/R/mlflow/DESCRIPTION
@@ -25,8 +25,7 @@ Imports:
   withr,
   xml2,
   yaml,
-  fs,
-  stringr
+  fs
 RoxygenNote: 6.0.1
 Suggests: 
   testthat

--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -51,8 +51,8 @@ mlflow_run <- function(uri, entry_point = NULL, param_list = NULL,
         config::merge(passed_params)
 
       # Return the script path.
-      script_path <- mlproject$entry_points[[entry_point]]$command %>%
-        stringr::str_extract("(?<=\").*\\.R")
+      command <- mlproject$entry_points[[entry_point]]$command
+      script_path <- regmatches(command, regexpr("(?<=\"|\').*\\.R", command, perl = TRUE))
       if (is.na(script_path))
         stop("Unable to extract script path from entry point entry for \"", entry_point, "\"",
              call. = FALSE)

--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -6,9 +6,13 @@
 #' @param uri A directory or an R script.
 #' @param entry_point Entry point within project, defaults to `main` if not specified.
 #' @param param_list A list of parameters.
+#' @param experiment_id ID of the experiment under which to launch the run.
 #'
 #' @export
-mlflow_run <- function(uri, entry_point = NULL, param_list = NULL) {
+mlflow_run <- function(uri, entry_point = NULL, param_list = NULL,
+                       experiment_id = NULL) {
+  if (!is.null(experiment_id)) mlflow_experiment(experiment_id)
+
   # Parameter value precedence:
   #   Command line args > `param_list` > MLProject defaults > defaults in script
   .globals$run_params <- list()

--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -3,12 +3,12 @@
 #' Runs the given file, expression or function within
 #' the context of an MLflow run.
 #'
-#' @param x A directory or an R script.
+#' @param uri A directory or an R script.
 #' @param entry_point Entry point within project, defaults to `main` if not specified.
 #' @param param_list A list of parameters.
 #'
 #' @export
-mlflow_run <- function(x, entry_point = NULL, param_list = NULL) {
+mlflow_run <- function(uri, entry_point = NULL, param_list = NULL) {
   # Parameter value precedence:
   #   Command line args > `param_list` > MLProject defaults > defaults in script
   .globals$run_params <- list()
@@ -16,11 +16,11 @@ mlflow_run <- function(x, entry_point = NULL, param_list = NULL) {
   passed_params <- config::merge(param_list, command_args)
 
   # Identify the script to run.
-  script <- if (fs::is_dir(x)) {
-    # If `x` is a directory, check for MLProject.
-    if (fs::file_exists(fs::path(x, "MLProject"))) {
+  script <- if (fs::is_dir(uri)) {
+    # If `uri` is a directory, check for MLProject.
+    if (fs::file_exists(fs::path(uri, "MLProject"))) {
       # MLProject found.
-      mlproject <- yaml::yaml.load_file(fs::path(x, "MLProject"))
+      mlproject <- yaml::yaml.load_file(fs::path(uri, "MLProject"))
       entry_points <- names(mlproject$entry_points)
 
       if (!is.null(entry_point)) {
@@ -58,7 +58,7 @@ mlflow_run <- function(x, entry_point = NULL, param_list = NULL) {
       script_path
     } else {
       # MLProject not found, we check if there's a single R script.
-      scripts <- fs::dir_ls(x, regexp = "\\.R$")
+      scripts <- fs::dir_ls(uri, regexp = "\\.R$")
       if (length(scripts) == 1) {
         # If there's a single R script, we'll use that as our entry point.
         scripts[[1]]
@@ -69,8 +69,8 @@ mlflow_run <- function(x, entry_point = NULL, param_list = NULL) {
       }
     }
   } else {
-    # `x` is a file, so we assume it's the R script to be executed.
-    x
+    # `uri` is a file, so we assume it's the R script to be executed.
+    uri
   }
 
   if (!is.null(passed_params)) {

--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -5,15 +5,15 @@
 #'
 #' @param x A directory or an R script.
 #' @param entry_point Entry point within project, defaults to `main` if not specified.
-#' @param params A list of parameters.
+#' @param param_list A list of parameters.
 #'
 #' @export
-mlflow_run <- function(x, entry_point = NULL, params = NULL) {
+mlflow_run <- function(x, entry_point = NULL, param_list = NULL) {
   # Parameter value precedence:
-  #   Command line args > `params` > MLProject defaults > defaults in script
+  #   Command line args > `param_list` > MLProject defaults > defaults in script
   .globals$run_params <- list()
   command_args <- parse_command_line(commandArgs(trailingOnly = TRUE))
-  passed_params <- config::merge(params, command_args)
+  passed_params <- config::merge(param_list, command_args)
 
   # Identify the script to run.
   script <- if (fs::is_dir(x)) {

--- a/R/mlflow/man/mlflow_run.Rd
+++ b/R/mlflow/man/mlflow_run.Rd
@@ -4,14 +4,14 @@
 \alias{mlflow_run}
 \title{Run in MLflow}
 \usage{
-mlflow_run(x, entry_point = NULL, params = NULL)
+mlflow_run(x, entry_point = NULL, param_list = NULL)
 }
 \arguments{
 \item{x}{A directory or an R script.}
 
 \item{entry_point}{Entry point within project, defaults to `main` if not specified.}
 
-\item{params}{A list of parameters.}
+\item{param_list}{A list of parameters.}
 }
 \description{
 Runs the given file, expression or function within

--- a/R/mlflow/man/mlflow_run.Rd
+++ b/R/mlflow/man/mlflow_run.Rd
@@ -5,7 +5,7 @@
 \title{Run in MLflow}
 \usage{
 mlflow_run(uri, entry_point = NULL, param_list = NULL,
-  experiment_id = NULL)
+  experiment_id = NULL, new_dir = FALSE)
 }
 \arguments{
 \item{uri}{A directory or an R script.}
@@ -15,6 +15,10 @@ mlflow_run(uri, entry_point = NULL, param_list = NULL,
 \item{param_list}{A list of parameters.}
 
 \item{experiment_id}{ID of the experiment under which to launch the run.}
+
+\item{new_dir}{If `TRUE`, copies the project into a temporary working directory and
+runs it from there. Otherwise, uses `uri` as the working directory when running the
+project.}
 }
 \description{
 Runs the given file, expression or function within

--- a/R/mlflow/man/mlflow_run.Rd
+++ b/R/mlflow/man/mlflow_run.Rd
@@ -4,7 +4,8 @@
 \alias{mlflow_run}
 \title{Run in MLflow}
 \usage{
-mlflow_run(uri, entry_point = NULL, param_list = NULL)
+mlflow_run(uri, entry_point = NULL, param_list = NULL,
+  experiment_id = NULL)
 }
 \arguments{
 \item{uri}{A directory or an R script.}
@@ -12,6 +13,8 @@ mlflow_run(uri, entry_point = NULL, param_list = NULL)
 \item{entry_point}{Entry point within project, defaults to `main` if not specified.}
 
 \item{param_list}{A list of parameters.}
+
+\item{experiment_id}{ID of the experiment under which to launch the run.}
 }
 \description{
 Runs the given file, expression or function within

--- a/R/mlflow/man/mlflow_run.Rd
+++ b/R/mlflow/man/mlflow_run.Rd
@@ -4,10 +4,10 @@
 \alias{mlflow_run}
 \title{Run in MLflow}
 \usage{
-mlflow_run(x, entry_point = NULL, param_list = NULL)
+mlflow_run(uri, entry_point = NULL, param_list = NULL)
 }
 \arguments{
-\item{x}{A directory or an R script.}
+\item{uri}{A directory or an R script.}
 
 \item{entry_point}{Entry point within project, defaults to `main` if not specified.}
 

--- a/R/mlflow/man/mlflow_run.Rd
+++ b/R/mlflow/man/mlflow_run.Rd
@@ -4,10 +4,12 @@
 \alias{mlflow_run}
 \title{Run in MLflow}
 \usage{
-mlflow_run(x, params = NULL)
+mlflow_run(x, entry_point = NULL, params = NULL)
 }
 \arguments{
 \item{x}{A directory or an R script.}
+
+\item{entry_point}{Entry point within project, defaults to `main` if not specified.}
 
 \item{params}{A list of parameters.}
 }


### PR DESCRIPTION
Changes:

- `mlflow_run()` now supports `entry_point`, `experiment_id`, and `new_dir` parameters.
- `mlflow_run()`: the following parameters have been renamed to be consistent with the Python API: `x` -> `uri`, `params` -> `param_list`.
- `mlflow_run()`supports taking a directory in addition to path to a script, in which case it looks for the `MLProject` file to determine which entry point to call.
- `mlflow_run()` now executes in the proper working directory determined by `uri` instead of the working directory of the user when `mlflow_run()` is called in the interactive session.
- `mlflow_snapshot()` is now called after the run is complete.