### PR TITLE
Fix command line argument parsing in mlflow_source()

### DIFF
--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -88,6 +88,8 @@ clear_run <- function() {
 # from rstudio/tfruns R/flags.R
 # parse command line arguments
 parse_command_line <- function(arguments) {
+  arguments <- arguments[!arguments == "--args"]
+
   if (!length(arguments)) return(NULL)
   # initialize some state
   values <- list()
@@ -100,10 +102,6 @@ parse_command_line <- function(arguments) {
     # skip any command line arguments without a '--' prefix
     if (!grepl("^--", argument))
       next
-
-    # terminate if we see "--args" (implies passthrough args)
-    if (grepl("^--args$", argument))
-      break
 
     # check to see if an '=' was specified for this argument
     equals_idx <- regexpr("=", argument)

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -57,7 +57,7 @@ class Project(object):
                 command = command.encode("utf-8")
             return EntryPoint(name=entry_point, parameters={}, command=command)
         elif file_extension == ".R":
-            command = "Rscript -e \"mlflow::mlflow_source('%s')\"" % shlex_quote(entry_point)
+            command = "Rscript -e \"mlflow::mlflow_source('%s')\" --args" % shlex_quote(entry_point)
             return EntryPoint(name=entry_point, parameters={}, command=command)
         raise ExecutionException("Could not find {0} among entry points {1} or interpret {0} as a "
                                  "runnable script. Supported script file extensions: "


### PR DESCRIPTION
Seems like `Rscript` has some weird behavior we need to work around...

Before the change:

```
Rscript -e "mlflow::mlflow_source('internal/script2.R')" --foo 65 --bar hi
WARNING: unknown option '--foo'

[1] "COMMAND ARGS:\n"
[1] "65"    "--bar" "hi"
```

and

```
Rscript -e "mlflow::mlflow_source('internal/script2.R')" --args  --foo 65 --bar hi
[1] "COMMAND ARGS:\n"
[1] "--foo"  "--args" "65"     "--bar"  "hi"
```

Note that `--args` shows up right after `--foo` so it gets parsed as a value. Fix is to filter `--args` out before parsing.

Also, added `--args` to the `Rscript` command in Python code.