### PR TITLE
`mlflow_start_run()` fixes

### DIFF
--- a/R/mlflow/DESCRIPTION
+++ b/R/mlflow/DESCRIPTION
@@ -14,6 +14,7 @@ Depends:
 Imports:
   config,
   fs,
+  git2r,
   httpuv,
   httr,
   jsonlite,

--- a/R/mlflow/R/connection.R
+++ b/R/mlflow/R/connection.R
@@ -1,7 +1,10 @@
 mlflow_get_or_create_active_connection <- function() {
   if (is.null(mlflow_active_connection())) {
-    mc <- mlflow_connect()
-    mlflow_set_active_connection(mc)
+    tracking_uri <- mlflow_tracking_uri()
+    if (startsWith(tracking_uri, "http"))
+      new_mlflow_connection(tracking_uri = tracking_uri, handle = NULL)
+    else
+      mlflow_connect(tracking_uri)
   }
 
   mlflow_active_connection()

--- a/R/mlflow/R/experiment-rest.R
+++ b/R/mlflow/R/experiment-rest.R
@@ -132,7 +132,7 @@ mlflow_get_run <- function(run_uuid) {
 #' @param timestamp Unix timestamp in milliseconds at the time metric was logged.
 #' @export
 mlflow_log_metric <- function(key, value, timestamp = NULL, run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid %||% mlflow_active_run())
+  run_uuid <- mlflow_ensure_run(run_uuid)
   timestamp <- timestamp %||% current_time()
   response <- mlflow_rest("runs", "log-metric", verb = "POST", data = list(
     run_uuid = run_uuid,
@@ -156,7 +156,7 @@ mlflow_log_metric <- function(key, value, timestamp = NULL, run_uuid = NULL) {
 #' @param value String value of the parameter.
 #' @export
 mlflow_log_param <- function(key, value, run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid %||% mlflow_active_run())
+  run_uuid <- mlflow_ensure_run(run_uuid)
   response <- mlflow_rest("runs", "log-parameter", verb = "POST", data = list(
     run_uuid = run_uuid,
     key = key,
@@ -175,7 +175,7 @@ mlflow_log_param <- function(key, value, run_uuid = NULL) {
 #' @param metric_key Name of the metric.
 #' @export
 mlflow_get_metric <- function(metric_key, run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid %||% mlflow_active_run())
+  run_uuid <- mlflow_ensure_run(run_uuid)
   response <- mlflow_rest("metrics", "get", query = list(
     run_uuid = run_uuid,
     metric_key = metric_key
@@ -194,7 +194,7 @@ mlflow_get_metric <- function(metric_key, run_uuid = NULL) {
 #' @param key Name of the metric.
 #' @export
 mlflow_get_metric_history <- function(metric_key, run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid %||% mlflow_active_run())
+  run_uuid <- mlflow_ensure_run(run_uuid)
   response <- mlflow_rest("metrics", "get-history", query = list(
     run_uuid = run_uuid,
     metric_key = metric_key
@@ -213,7 +213,7 @@ mlflow_get_metric_history <- function(metric_key, run_uuid = NULL) {
 mlflow_update_run <- function(status = c("FINISHED", "SCHEDULED", "FAILED", "KILLED"),
                               end_time = NULL,
                               run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid %||% mlflow_active_run())
+  run_uuid <- mlflow_ensure_run(run_uuid)
   status <- match.arg(status)
   end_time <- end_time %||% current_time()
 

--- a/R/mlflow/R/experiment-rest.R
+++ b/R/mlflow/R/experiment-rest.R
@@ -104,8 +104,6 @@ mlflow_create_run <- function(user_id = NULL,
     run_tags = run_tags
   ))
 
-  .globals$active_run <- response$run$info$run_uuid
-
   as.data.frame(response$run$info, stringsAsFactors = FALSE)
 }
 
@@ -116,8 +114,7 @@ mlflow_create_run <- function(user_id = NULL,
 #' @param run_uuid Unique ID for the run.
 #'
 #' @export
-mlflow_get_run <- function(run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid %||% mlflow_active_run())
+mlflow_get_run <- function(run_uuid) {
   response <- mlflow_rest("runs", "get", query = list(run_uuid = run_uuid))
   run <- Filter(length, response$run)
   lapply(run, as.data.frame, stringsAsFactors = FALSE)

--- a/R/mlflow/R/experiment.R
+++ b/R/mlflow/R/experiment.R
@@ -141,17 +141,10 @@ with.mlflow_active_run <- function(x, code) {
 
 mlflow_ensure_run <- function(run_uuid) {
   if (is.null(run_uuid)) {
-    # ensure connection is available and initialized
-    mlflow_get_or_create_active_connection()
-
-    # create active run
-    mlflow_create_run()
-
-    # retrieve active run
-    run_uuid <- mlflow_active_run()
+    mlflow_active_run()$run_info$run_uuid %||% mlflow_start_run()$run_info$run_uuid
+  } else {
+    mlflow_start_run(run_uuid)$run_info$run_uuid
   }
-
-  run_uuid
 }
 
 #' Log Artifact

--- a/R/mlflow/R/experiment.R
+++ b/R/mlflow/R/experiment.R
@@ -109,7 +109,7 @@ mlflow_start_run <- function(run_uuid = NULL, experiment_id = NULL, source_name 
       source_name = source_name %||% get_source_name(),
       source_version = source_version %||% get_source_version(),
       entry_point_name = entry_point_name,
-      source_type = source_type %||% get_source_type()
+      source_type = source_type
     )
   }
 

--- a/R/mlflow/R/rest.R
+++ b/R/mlflow/R/rest.R
@@ -38,14 +38,10 @@ mlflow_rest_timeout <- function() {
 mlflow_rest <- function(..., query = NULL, data = NULL, verb = "GET", version = "2.0") {
   args <- list(...)
 
-  tracking_uri <- mlflow_tracking_uri()
-  tracking_uri <- if (startsWith(tracking_uri, "http")) tracking_uri else {
-    mc <- mlflow_connect()
-    mc$tracking_uri
-  }
+  mc <- mlflow_get_or_create_active_connection()
 
   api_url <- file.path(
-    tracking_uri,
+    mc$tracking_uri,
     mlflow_rest_path(version),
     paste(args, collapse = "/")
   )

--- a/R/mlflow/man/mlflow_get_run.Rd
+++ b/R/mlflow/man/mlflow_get_run.Rd
@@ -4,7 +4,7 @@
 \alias{mlflow_get_run}
 \title{Get Run}
 \usage{
-mlflow_get_run(run_uuid = NULL)
+mlflow_get_run(run_uuid)
 }
 \arguments{
 \item{run_uuid}{Unique ID for the run.}

--- a/R/mlflow/man/mlflow_start_run.Rd
+++ b/R/mlflow/man/mlflow_start_run.Rd
@@ -4,37 +4,27 @@
 \alias{mlflow_start_run}
 \title{Start Run}
 \usage{
-mlflow_start_run(user_id = NULL, run_name = NULL, source_type = NULL,
-  source_name = NULL, status = NULL, start_time = NULL, end_time = NULL,
-  source_version = NULL, artifact_uri = NULL, entry_point_name = NULL,
-  run_tags = NULL, experiment_id = NULL)
+mlflow_start_run(run_uuid = NULL, experiment_id = NULL,
+  source_name = NULL, source_version = NULL, entry_point_name = NULL,
+  source_type = "LOCAL")
 }
 \arguments{
-\item{user_id}{User ID or LDAP for the user executing the run.}
+\item{run_uuid}{If specified, get the run with the specified UUID and log metrics
+and params under that run. The run's end time is unset and its status is set to
+running, but the run's other attributes remain unchanged.}
 
-\item{run_name}{Human readable name for run.}
+\item{experiment_id}{Used only when ``run_uuid`` is unspecified. ID of the experiment under
+which to create the current run. If unspecified, the run is created under
+a new experiment with a randomly generated name.}
 
-\item{source_type}{Originating source for this run. One of Notebook, Job, Project, Local or Unknown.}
+\item{source_name}{Name of the source file or URI of the project to be associated with the run.
+Defaults to the current file if none provided.}
 
-\item{source_name}{String descriptor for source. For example, name or description of the notebook, or job name.}
+\item{source_version}{Optional Git commit hash to associate with the run.}
 
-\item{status}{Current status of the run. One of RUNNING, SCHEDULE, FINISHED, FAILED, KILLED.}
+\item{entry_point_name}{Optional name of the entry point for to the current run.}
 
-\item{start_time}{Unix timestamp of when the run started in milliseconds.}
-
-\item{end_time}{Unix timestamp of when the run ended in milliseconds.}
-
-\item{source_version}{Git version of the source code used to create run.}
-
-\item{artifact_uri}{URI of the directory where artifacts should be uploaded This can be a local path (starting with “/”),
-or a distributed file system (DFS) path, like s3://bucket/directory or dbfs:/my/directory. If not set, the local ./mlruns
-directory will be chosen by default.}
-
-\item{entry_point_name}{Name of the entry point for the run.}
-
-\item{run_tags}{Additional metadata for run in key-value pairs.}
-
-\item{experiment_id}{Unique identifier for the associated experiment.}
+\item{source_type}{Integer enum value describing the type of the run  ("local", "project", etc.).}
 }
 \description{
 Starts a new run within an experiment, should be used within a \code{with} block.


### PR DESCRIPTION
- Redesign `mlflow_start_run()` to better match Python API; now captures environment variables correctly so we don't start another experiment run.
- `mlflow_get_or_create_active_connection()` now checks for tracking URI.
- Refactor `mlflow_ensure_run()` to check for active runs.
- `mlflow_create_run()` no longer incorrectly modifies `.globals$active_run`.
- git2r has been imported to facilitate git commit tracking features.